### PR TITLE
Implement package extensions for PyPlot and PythonPlot

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,6 +11,9 @@ concurrency:
   # Cancel intermediate builds: only if it is a pull request build.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+env:
+  # Force Julia to use its own Python install via miniforge
+  PYTHON: ""
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,5 +70,5 @@ jobs:
         run: |
           using Documenter: DocMeta, doctest
           using MicroFloatingPoints
-          DocMeta.setdocmeta!(MicroFloatingPoints, :DocTestSetup, :(using MicroFloatingPoints); recursive=true)
+          DocMeta.setdocmeta!(MicroFloatingPoints, :DocTestSetup, :(using MicroFloatingPoints, MicroFloatingPoints.MFPRandom, MicroFloatingPoints.MFPPlot, MicroFloatingPoints.MFPUtils); recursive=true)
           doctest(MicroFloatingPoints)

--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,23 @@
 name = "MicroFloatingPoints"
 uuid = "6e0295d3-a2ae-4d9e-ab31-7b55fc0f4333"
 authors = ["Frédéric Goualard <Frederic.Goualard@univ-nantes.fr>"]
-version = "1.5.3"
+version = "2.0.0"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
+[weakdeps]
+PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
+PythonPlot = "274fc56d-3b97-40fa-a1cd-1b4a50311bf9"
+
+[extensions]
+MFPPyPlot = "PyPlot"
+MFPPythonPlot = "PythonPlot"
+
 [compat]
-PyPlot = "2"
 Printf = "1.10"
+PyPlot = "2"
+PythonPlot = "1"
 Random = "1.10"
 julia = "1.10"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,22 @@ Or, equivalently, via the Pkg API:
 julia> import Pkg; Pkg.add("MicroFloatingPoints")
 ```
 
-Note that the `matplotlib` Python package must be available through `PyCall`.
+Optionally, to enable plotting, install either one of PyPlot.jl or PythonPlot.jl as follows.
+
+```julia-repl
+julia> import Pkg; Pkg.add("PyPlot")
+```
+
+OR
+
+```julia-repl
+julia> import Pkg; Pkg.add("PythonPlot")
+```
+
+Note that the `matplotlib` Python package must be available through `PyCall` or `PythonCall`.
+This is usually setup when installing [PyPlot.jl](https://github.com/JuliaPy/PyPlot.jl)
+or [PythonPlot.jl](https://github.com/JuliaPy/PythonPlot.jl), which are optional (weak) dependencies
+that provide plotting backends via package extensions.
 
 
 ## Documentation

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -30,12 +30,6 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
-[[deps.Calculus]]
-deps = ["LinearAlgebra"]
-git-tree-sha1 = "f641eb0a4f00c343bbc32346e1217b86f3ce9dad"
-uuid = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
-version = "0.5.1"
-
 [[deps.CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
 git-tree-sha1 = "bce6804e5e6044c6daab27bb533d1295e4a2e759"
@@ -92,9 +86,9 @@ uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [[deps.Distributions]]
 deps = ["AliasTables", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsFuns"]
-git-tree-sha1 = "0e0a1264b0942f1f3abb2b30891f2a590cc652ac"
+git-tree-sha1 = "e6c693a0e4394f8fda0e51a5bdf5aef26f8235e9"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
-version = "0.25.110"
+version = "0.25.111"
 
     [deps.Distributions.extensions]
     DistributionsChainRulesCoreExt = "ChainRulesCore"
@@ -114,20 +108,14 @@ version = "0.9.3"
 
 [[deps.Documenter]]
 deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "CodecZlib", "Dates", "DocStringExtensions", "Downloads", "Git", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "MarkdownAST", "Pkg", "PrecompileTools", "REPL", "RegistryInstances", "SHA", "TOML", "Test", "Unicode"]
-git-tree-sha1 = "76deb8c15f37a3853f13ea2226b8f2577652de05"
+git-tree-sha1 = "9d29b99b6b2b6bc2382a4c8dbec6eb694f389853"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "1.5.0"
+version = "1.6.0"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 version = "1.6.0"
-
-[[deps.DualNumbers]]
-deps = ["Calculus", "NaNMath", "SpecialFunctions"]
-git-tree-sha1 = "5837a837389fccf076445fce071c8ddaea35a566"
-uuid = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
-version = "0.6.8"
 
 [[deps.Expat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -140,9 +128,9 @@ uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[deps.FillArrays]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "0653c0a2396a6da5bc4766c43041ef5fd3efbe57"
+git-tree-sha1 = "fd0002c0b5362d7eb952450ad5eb742443340d6e"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.11.0"
+version = "1.12.0"
 weakdeps = ["PDMats", "SparseArrays", "Statistics"]
 
     [deps.FillArrays.extensions]
@@ -169,10 +157,10 @@ uuid = "f8c6e375-362e-5223-8a59-34ff63f689eb"
 version = "2.44.0+2"
 
 [[deps.HypergeometricFunctions]]
-deps = ["DualNumbers", "LinearAlgebra", "OpenLibm_jll", "SpecialFunctions"]
-git-tree-sha1 = "f218fe3736ddf977e0e772bc9a586b2383da2685"
+deps = ["LinearAlgebra", "OpenLibm_jll", "SpecialFunctions"]
+git-tree-sha1 = "7c4195be1649ae622304031ed46a2f4df989f1eb"
 uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
-version = "0.3.23"
+version = "0.3.24"
 
 [[deps.IOCapture]]
 deps = ["Logging", "Random"]
@@ -289,10 +277,18 @@ uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
 version = "2.28.2+1"
 
 [[deps.MicroFloatingPoints]]
-deps = ["Printf", "PyPlot", "Random"]
+deps = ["Printf", "Random"]
 path = ".."
 uuid = "6e0295d3-a2ae-4d9e-ab31-7b55fc0f4333"
-version = "1.5.3"
+version = "2.0.0"
+
+    [deps.MicroFloatingPoints.extensions]
+    MFPPyPlot = "PyPlot"
+    MFPPythonPlot = "PythonPlot"
+
+    [deps.MicroFloatingPoints.weakdeps]
+    PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
+    PythonPlot = "274fc56d-3b97-40fa-a1cd-1b4a50311bf9"
 
 [[deps.Missings]]
 deps = ["DataAPI"]
@@ -306,12 +302,6 @@ uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 version = "2023.1.10"
-
-[[deps.NaNMath]]
-deps = ["OpenLibm_jll"]
-git-tree-sha1 = "0877504529a3e5c3343c6f8b4c0381e57e4387e4"
-uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
-version = "1.0.2"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,7 @@ using MicroFloatingPoints.MFPRandom
 using MicroFloatingPoints.MFPPlot
 using MicroFloatingPoints.MFPUtils
 
-DocMeta.setdocmeta!(MicroFloatingPoints, :DocTestSetup, :(using MicroFloatingPoints, MicroFloatingPoints.MFPRandom, MicroFloatingPoints.MFPPlot, MicroFloatingPoints.MFPUtils, PyPlot); recursive=true)
+DocMeta.setdocmeta!(MicroFloatingPoints, :DocTestSetup, :(using MicroFloatingPoints, MicroFloatingPoints.MFPRandom, MicroFloatingPoints.MFPPlot, MicroFloatingPoints.MFPUtils); recursive=true)
 
 makedocs(
     sitename="The MicroFloatingPoints Documentation",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,7 @@ using MicroFloatingPoints.MFPRandom
 using MicroFloatingPoints.MFPPlot
 using MicroFloatingPoints.MFPUtils
 
-DocMeta.setdocmeta!(MicroFloatingPoints, :DocTestSetup, :(using MicroFloatingPoints, MicroFloatingPoints.MFPRandom, MicroFloatingPoints.MFPPlot, MicroFloatingPoints.MFPUtils); recursive=true)
+DocMeta.setdocmeta!(MicroFloatingPoints, :DocTestSetup, :(using MicroFloatingPoints, MicroFloatingPoints.MFPRandom, MicroFloatingPoints.MFPPlot, MicroFloatingPoints.MFPUtils, PyPlot); recursive=true)
 
 makedocs(
     sitename="The MicroFloatingPoints Documentation",

--- a/docs/src/guided-tour.md
+++ b/docs/src/guided-tour.md
@@ -44,18 +44,13 @@ floatmin(MuFP)
 ```
 ## Graphics with `MicroFloatingPoints.MFPPlot`
 
-The `MicroFloatingPoints` package offers several graphical functionnalities that are all available in `MicroFloatingPoints.MFPPlot`:
+The `MicroFloatingPoints` package offers several graphical functionalities that are all available in `MicroFloatingPoints.MFPPlot` when the plotting package `PyPlot` is also loaded:
 
 ```@repl realline
-using MicroFloatingPoints.MFPPlot
+using MicroFloatingPoints.MFPPlot, PyPlot
 ```
 
-Should you require additional graphical elements, you need to load explicitly the `PyPlot` package too:
-
-
-```@repl realline
-using PyPlot
-```
+Loading `PyPlot` will trigger the loading of a package extension. Alternatively, `PythonPlot` can also be used with the alias `const plt = pyplot`.
 
 To better assess what we can do with such a small type, let us display all finite representable values on the real line. The `MFPPlot` module has just the right method:
 ```@repl realline

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -347,6 +347,13 @@ julia> rand(Uniform(Floatmu{2,2}(-1.0),Floatmu{2,2}(1.0)))
 CurrentModule = MicroFloatingPoints.MFPPlot
 ```
 The `MicroFloatingPoints.MFPPlot` module offers some methods to easily represent floating-point numbers.
+It currently supports both `PyPlot` and `PythonPlot` backends, one of which must be loaded.
+To use `PythonPlot`, replace references to `PyPlot` with `PythonPlot` below and create the following alias
+for `plt`.
+
+```
+const plt = PythonCall.pyplot
+```
 
 ```@docs
 real_line
@@ -386,7 +393,7 @@ savefig("realline_Floatmu23b.svg"); nothing # hide
 ```
 
 ```@docs
-bits_histogram(T::Vector{Floatmu{szE,szf}}) where {szE,szf}
+bits_histogram
 ```
 
 ```@setup bits-histogram-example

--- a/ext/MFPPlot_common.jl
+++ b/ext/MFPPlot_common.jl
@@ -1,76 +1,14 @@
-# MFPPlot --
-#
-# Copyright 2019--2024 University of Nantes, France.
-#
-# This file is part of the MicroFloatingPoints library.
-#
-# The MicroFloatingPoints library is free software; you can redistribute
-# it and/or modify it under the terms of the GNU Lesser General Public License
-# as published by the Free Software Foundation; either version 3 of the
-# License, or (at your option) any later version.
-#
-# The MicroFloatingPoints library is distributed in the hope that it will be
-# useful, but	WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-# See the GNU General Public License for more details.
-#	
-# You should have received copies of the GNU General Public License and the
-# GNU Lesser General Public License along with the MicroFloatingPoints Library.
-# If not, see https://www.gnu.org/licenses/.
+# common include of both MFPPyPlot.jl and MFPPythonPlot.jl
+# For MFPPythonPlot.jl, `const plt = pyplot`.
 
-module MFPPlot
-
-using PyPlot
-using ..MicroFloatingPoints
-using ..MicroFloatingPoints.MFPUtils: vertical_popcount
+using MicroFloatingPoints
+using MicroFloatingPoints.MFPUtils: vertical_popcount
+import MicroFloatingPoints.MFPPlot: real_line, bits_histogram
 
 export real_line
 export bits_histogram
 
-"""
-    real_line(start::Floatmu{szE,szf}, stop::Floatmu{szE,szf};
-              ticks = true, 
-              fpcolorsub = "purple", fpcolornorm = "blue") where {szE,szf}
-    real_line(::Type{Floatmu{szE,szf}};
-              ticks = true, 
-              fpcolorsub = "purple", fpcolornorm = "blue",
-              fpcolorinf="orange") where {szE,szf}
-    real_line(T::Vector{Floatmu{szE,szf}};
-                   ticks = true, fpcolorsub = "purple", fpcolornorm = "blue",
-                   fpcolorinf="orange") where {szE,szf}
-
-Draw floats on the real line.
-
-The first version draws the real line between `start` and `stop` and displays all floating-point
-numbers with `sze` bits exponent and `szf` bits fractional part. The second version draws all finite 
-floating-point for the format `Floatmu{szE,szf}` and adds the infinities where the next/previous 
-float would be with the format `Floatmu{szE+1,szf}`. The third version draws all floats in the 
-vector `T`.
-
-In the first version, both parameters `start` and `stop` must be finite. An `ArgumentError` exception
-is raised otherwise. The same goes for all values in `T` for the third version.
-
-All versions return the figure used for the plot.
-
-The figure may be customized through the named parameters:
-- `ticks`: if `true`, draws a vertical line for each float and adds the value below. If
-    `false`, represent each float by a dot on the real line, without its value;
-- `fpcolorsub`: color of the line or dot used to represent subnormals;
-- `fpcolornorm`: color of the line or dot used to represent normal values;
-- `fpcolorinf` [for the second version only]: color of the line or dot used to represent infinite values.
-
-# Examples of calls
-
-```@repl
-real_line(-floatmax(Floatmu{2,2}),floatmax(Floatmu{2,2}));
-real_line(Floatmu{2,2});
-real_line(Floatmu{2,2}[-3.5,0.25,1.5,2.0])
-```
-"""
-function real_line end
-
-
-function real_line(T::Vector{Floatmu{szE,szf}};
+function real_line(::Val{@__MODULE__}, T::Vector{Floatmu{szE,szf}};
                    ticks = true, fpcolorsub = "purple", fpcolornorm = "blue",
                    fpcolorinf="orange") where {szE,szf}
     all(isfinite,T) || throw(ArgumentError("parameters must be finite"))
@@ -107,7 +45,7 @@ function real_line(T::Vector{Floatmu{szE,szf}};
 end
 
 
-function real_line(start::Floatmu{szE,szf}, stop::Floatmu{szE,szf};
+function real_line(::Val{@__MODULE__}, start::Floatmu{szE,szf}, stop::Floatmu{szE,szf};
                    ticks = true, fpcolorsub = "purple", fpcolornorm = "blue") where {szE,szf}
     # This version could be rewritten as:
     # `real_line(collect(FloatmuIterator(start,stop)))`
@@ -146,7 +84,8 @@ function real_line(start::Floatmu{szE,szf}, stop::Floatmu{szE,szf};
     return fig
 end 
 
-function real_line(::Type{Floatmu{szE,szf}};
+
+function real_line(::Val{@__MODULE__}, ::Type{Floatmu{szE,szf}};
                    ticks = true, fpcolorsub = "purple", fpcolornorm = "blue",
                    fpcolorinf="orange") where {szE,szf}
     posInf = nextfloat(Floatmu{szE+1,szf}(floatmax(Floatmu{szE,szf})))
@@ -161,17 +100,7 @@ function real_line(::Type{Floatmu{szE,szf}};
 end
 
 
-                   
-"""
-    bits_histogram(T::Vector{Floatmu{szE,szf}};
-                   signcolor = "magenta",
-                   expcolor = "darkolivegreen",
-                   fraccolor = "blue") where {szE,szf}
-
-Draw an histogram of the probability of each bit of the representation of a float
-to be `1` in the sample `T`.
-"""
-function bits_histogram(T::Vector{Floatmu{szE,szf}};
+function bits_histogram(::Val{@__MODULE__}, T::Vector{Floatmu{szE,szf}};
                         signcolor = "magenta",
                         expcolor = "darkolivegreen",
                         fraccolor = "blue") where {szE,szf}
@@ -190,5 +119,6 @@ function bits_histogram(T::Vector{Floatmu{szE,szf}};
     return nothing
 end
 
-
-end # Module
+function __init__()
+    MicroFloatingPoints.MFPPlot.register_backend(@__MODULE__)
+end

--- a/ext/MFPPyPlot.jl
+++ b/ext/MFPPyPlot.jl
@@ -1,4 +1,4 @@
-# MicroFloatingPoints --
+# MFPPlot --
 #
 # Copyright 2019--2024 University of Nantes, France.
 #
@@ -18,26 +18,10 @@
 # GNU Lesser General Public License along with the MicroFloatingPoints Library.
 # If not, see https://www.gnu.org/licenses/.
 
-module MicroFloatingPoints
+module MFPPyPlot
 
-export Floatmu
-export μ, λ, NaNμ, Infμ
-export FloatmuIterator
-export isinexact, errorsign, reset_inexact, inexact
-export Emax, Emin, nb_fp_numbers, bias
-export eligible_step
-export fractional_even
+using PyPlot
 
-include("Floatmu.jl")
+include("MFPPlot_common.jl")
 
-# Submodule MFPUtils
-include("MFPUtils.jl")
-
-# Stub MFPPlot, see ../ext/MFPPlot.jl
-include("MFPPlotStub.jl")
-
-# Submodule MFPRandom
-include("MFPRandom.jl")
-
-
-end # module
+end # Module

--- a/ext/MFPPythonPlot.jl
+++ b/ext/MFPPythonPlot.jl
@@ -1,4 +1,4 @@
-# MicroFloatingPoints --
+# MFPPlot --
 #
 # Copyright 2019--2024 University of Nantes, France.
 #
@@ -18,26 +18,11 @@
 # GNU Lesser General Public License along with the MicroFloatingPoints Library.
 # If not, see https://www.gnu.org/licenses/.
 
-module MicroFloatingPoints
+module MFPPythonPlot
 
-export Floatmu
-export μ, λ, NaNμ, Infμ
-export FloatmuIterator
-export isinexact, errorsign, reset_inexact, inexact
-export Emax, Emin, nb_fp_numbers, bias
-export eligible_step
-export fractional_even
+using PythonPlot
+const plt = PythonPlot.pyplot
 
-include("Floatmu.jl")
+include("MFPPlot_common.jl")
 
-# Submodule MFPUtils
-include("MFPUtils.jl")
-
-# Stub MFPPlot, see ../ext/MFPPlot.jl
-include("MFPPlotStub.jl")
-
-# Submodule MFPRandom
-include("MFPRandom.jl")
-
-
-end # module
+end # Module

--- a/src/MFPPlotStub.jl
+++ b/src/MFPPlotStub.jl
@@ -1,0 +1,105 @@
+module MFPPlot
+
+using ..MicroFloatingPoints
+
+export real_line
+export bits_histogram
+
+# Backend plotting registry
+const backends = Vector{Module}()
+
+# register_backend is called by extension package __init__ methods
+function register_backend(m::Module)
+    push!(backends, m)
+end
+
+# set_backend! provides a method to choose which backend to use in case
+# multiple backends are loaded
+function set_backend!(m::Module)
+    pushfirst!(backends, m)
+end
+
+function set_backend!(s::Symbol)
+    if s == :PyPlot
+        s = :MFPPyPlot
+    elseif s == :PythonPlot
+        s = :MFPPythonPlot
+    end
+    m = Base.get_extension(MicroFloatingPoints, s)
+    set_backend!(m)
+end
+
+# called by real_line and bits_histogram
+function select_backend()
+    if isempty(backends)
+        error("One of PyPlot.jl or PythonPlot.jl must be loaded for plotting via MFPPlot. For example, run `using PythonPlot`.")
+    end
+    return first(backends)
+end
+
+
+
+"""
+    real_line(start::Floatmu{szE,szf}, stop::Floatmu{szE,szf};
+              ticks = true, 
+              fpcolorsub = "purple", fpcolornorm = "blue") where {szE,szf}
+    real_line(::Type{Floatmu{szE,szf}};
+              ticks = true, 
+              fpcolorsub = "purple", fpcolornorm = "blue",
+              fpcolorinf="orange") where {szE,szf}
+    real_line(T::Vector{Floatmu{szE,szf}};
+                   ticks = true, fpcolorsub = "purple", fpcolornorm = "blue",
+                   fpcolorinf="orange") where {szE,szf}
+
+Draw floats on the real line.
+
+The first version draws the real line between `start` and `stop` and displays all floating-point
+numbers with `sze` bits exponent and `szf` bits fractional part. The second version draws all finite 
+floating-point for the format `Floatmu{szE,szf}` and adds the infinities where the next/previous 
+float would be with the format `Floatmu{szE+1,szf}`. The third version draws all floats in the 
+vector `T`.
+
+In the first version, both parameters `start` and `stop` must be finite. An `ArgumentError` exception
+is raised otherwise. The same goes for all values in `T` for the third version.
+
+All versions return the figure used for the plot.
+
+The figure may be customized through the named parameters:
+- `ticks`: if `true`, draws a vertical line for each float and adds the value below. If
+    `false`, represent each float by a dot on the real line, without its value;
+- `fpcolorsub`: color of the line or dot used to represent subnormals;
+- `fpcolornorm`: color of the line or dot used to represent normal values;
+- `fpcolorinf` [for the second version only]: color of the line or dot used to represent infinite values.
+
+# Examples of calls
+
+```@repl
+real_line(-floatmax(Floatmu{2,2}),floatmax(Floatmu{2,2}));
+real_line(Floatmu{2,2});
+real_line(Floatmu{2,2}[-3.5,0.25,1.5,2.0])
+```
+"""
+function real_line end
+
+function real_line(args...; kwargs...)
+    backend_val = Val(select_backend())
+    real_line(backend_val, args...; kwargs...)
+end
+
+"""
+    bits_histogram(T::Vector{Floatmu{szE,szf}};
+                   signcolor = "magenta",
+                   expcolor = "darkolivegreen",
+                   fraccolor = "blue") where {szE,szf}
+
+Draw an histogram of the probability of each bit of the representation of a float
+to be `1` in the sample `T`.
+"""
+function bits_histogram end
+
+function bits_histogram(args...; kwargs...)
+    backend_val = Val(select_backend())
+    bits_histogram(backend_val, args...; kwargs...)
+end
+
+end

--- a/src/MFPUtils.jl
+++ b/src/MFPUtils.jl
@@ -34,7 +34,7 @@ For this function, the rightmost bit of the binary representation of a `Floatmu`
 
 # Examples
 
-```jldoctest
+```jldoctest; setup = :(using MicroFloatingPoints, MicroFloatingPoints.MFPUtils)
 julia> join(string.(reverse(vertical_popcount(Floatmu{2,2}[1.5])))) == bitstring(Floatmu{2,2}(1.5))
 true
 ```

--- a/src/MFPUtils.jl
+++ b/src/MFPUtils.jl
@@ -34,14 +34,13 @@ For this function, the rightmost bit of the binary representation of a `Floatmu`
 
 # Examples
 
-```jldoctest; setup = :(using MicroFloatingPoints, MicroFloatingPoints.MFPUtils)
+```jldoctest
 julia> join(string.(reverse(vertical_popcount(Floatmu{2,2}[1.5])))) == bitstring(Floatmu{2,2}(1.5))
 true
 ```
 Note that, in the preceding example, we have to revert the array obtained from `vertical_popcount` because the number of times bit `i` is `1` is saved at position `i`. As a consequence, the value for the rightmost bit of a `Floatmu` appears at the leftmost position of the counting array.
 
-```jldoctest; setup = :(using MicroFloatingPoints, MicroFloatingPoints.MFPUtils)
-
+```jldoctest
 julia> println(vertical_popcount(Floatmu{2,2}[0.25,1.5,3.0]))
 [1, 2, 1, 1, 0]
 ```

--- a/src/MFPUtils.jl
+++ b/src/MFPUtils.jl
@@ -40,7 +40,8 @@ true
 ```
 Note that, in the preceding example, we have to revert the array obtained from `vertical_popcount` because the number of times bit `i` is `1` is saved at position `i`. As a consequence, the value for the rightmost bit of a `Floatmu` appears at the leftmost position of the counting array.
 
-```jldoctest
+```jldoctest; setup = :(using MicroFloatingPoints, MicroFloatingPoints.MFPUtils)
+
 julia> println(vertical_popcount(Floatmu{2,2}[0.25,1.5,3.0]))
 [1, 2, 1, 1, 0]
 ```

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestSetExtensions = "98d24dd4-01ad-11ea-1b02-c9a08f80db04"
+PythonPlot = "274fc56d-3b97-40fa-a1cd-1b4a50311bf9"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,9 @@ using MicroFloatingPoints.MFPUtils
 using MicroFloatingPoints.MFPRandom
 using MicroFloatingPoints.MFPPlot
 
+# Test loading MFPPythonPlot
+using PythonPlot
+
 # Calling "julia runtests.jl" launches all tests in the directory.
 @testset ExtendedTestSet "All the tests" begin
     @testset "Arithmetic tests" begin


### PR DESCRIPTION
This pull request is apart of a JOSS Review and implements package extensions for PyPlot and PythonPlot. This also makes PyPlot a weak (optional) dependency.

To plot either [PyPlot](https://github.com/JuliaPy/PyPlot.jl) or [PythonPlot](https://github.com/JuliaPy/PythonPlot.jl) must be loaded.

PythonPlot is a modern versiion of PyPlot.jl that uses PythonCall.jl rather than PyCall.jl for Python interop. PythonCall.jl uses micromamba to track dependencies on a per-project basis.

It can be used as follows.

```julia
using MicroFloatingPoints, MicroFloatingPoints.MFPPlot, PythonPlot
const MuFP = Floatmu{2,2}
real_line(-floatmax(MuFP),floatmax(MuFP));
```

PythonPlot does not export `plt` but `pyplot`. We can create an alias for compatability. The examples can be used with `PythonPlot` along with the alias as follows.

```julia
using PythonPlot
const plt = pyplot
plt.figure()
plt.title("Exhaustive search for rounded sums in Floatmu{2,2}")
TotalIterator = FloatmuIterator(-floatmax(MuFP),floatmax(MuFP))
N = length(TotalIterator)
Z = zeros(Int,N,N)
let i = 1
    for v1 in TotalIterator
        j = 1
        for v2 in TotalIterator
            reset_inexact()
            v=v1+v2
            Z[i,j] = 0
            if inexact()
                Z[i,j] = isfinite(v) ? 1 : 2
            end
            j += 1
        end
        i += 1
    end
end
V = collect(TotalIterator)
plt.imshow(Z,origin="lower", cmap="Oranges")
plt.yticks(0:(length(V)-1),[string(V[i]) for i in 1:length(V)])
plt.xticks(0:(length(V)-1),[string(V[i]) for i in 1:length(V)],rotation=90);

```
